### PR TITLE
Hide exception classes in activity view

### DIFF
--- a/app/src/main/java/org/instedd/geochat/lgw/LogsActivity.java
+++ b/app/src/main/java/org/instedd/geochat/lgw/LogsActivity.java
@@ -2,8 +2,10 @@ package org.instedd.geochat.lgw;
 
 import org.instedd.geochat.lgw.data.GeoChatLgw.Logs;
 
+import android.app.AlertDialog;
 import android.app.ListActivity;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.os.Bundle;
@@ -11,6 +13,8 @@ import android.text.format.DateUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.ListView;
 import android.widget.SimpleCursorAdapter;
 import android.widget.TextView;
 
@@ -32,6 +36,31 @@ public class LogsActivity extends ListActivity {
                 new String[] { }, new int[] { });
         
         setListAdapter(adapter);
+
+		ListView lv = getListView();
+		lv.setLongClickable(true);
+
+		lv.setOnItemLongClickListener(new AdapterView.OnItemLongClickListener() {
+			@Override
+			public boolean onItemLongClick(AdapterView<?> adapterView, View view, int i, long l) {
+				cursor.moveToPosition(i);
+				final String stackTrace = cursor.getString(cursor.getColumnIndex(Logs.STACK_TRACE));
+				if (stackTrace != null && !stackTrace.equals("")) {
+					AlertDialog.Builder builder = new AlertDialog.Builder(view.getContext());
+					builder.setTitle("Error");
+					builder.setMessage(stackTrace);
+					builder.setNegativeButton("Close", new DialogInterface.OnClickListener() {
+						@Override
+						public void onClick(DialogInterface dialogInterface, int i) {
+							dialogInterface.dismiss();
+						}
+					});
+					builder.show();
+					return true;
+				}
+				return false;
+			}
+		});
     }
 	
 	private static class LogsCursorAdapter extends SimpleCursorAdapter {

--- a/app/src/main/java/org/instedd/geochat/lgw/trans/Transceiver.java
+++ b/app/src/main/java/org/instedd/geochat/lgw/trans/Transceiver.java
@@ -1,14 +1,19 @@
 package org.instedd.geochat.lgw.trans;
 
+import java.net.ConnectException;
 import java.util.ArrayList;
+import java.util.logging.Logger;
 
+import org.apache.http.conn.HttpHostConnectException;
 import org.instedd.geochat.lgw.Connectivity;
 import org.instedd.geochat.lgw.Settings;
 import org.instedd.geochat.lgw.Notifier;
 import org.instedd.geochat.lgw.R;
+import org.instedd.geochat.lgw.UnauthorizedException;
 import org.instedd.geochat.lgw.Uris;
 import org.instedd.geochat.lgw.data.GeoChatLgwData;
 import org.instedd.geochat.lgw.msg.Message;
+import org.instedd.geochat.lgw.msg.NuntiumClientException;
 import org.instedd.geochat.lgw.msg.QstClient;
 import org.instedd.geochat.lgw.msg.QstClientException;
 import org.instedd.geochat.lgw.msg.Status;
@@ -312,10 +317,16 @@ public class Transceiver {
 											R.string.fatal_error,
 											R.string.fix_host)).append(
 									"\n");
-						} catch (Throwable t) {
+						} catch(UnauthorizedException e) {
 							log.append(
 									r.getString(R.string.fatal_error,
-											t.getMessage())).append("\n");
+											e.getMessage())).append("\n");
+							throwable = e;
+						} catch (QstClientException e) {
+							log.append(r.getString(R.string.qst_client_error)).append("\n");
+							throwable = e;
+                        } catch (Throwable t) {
+							log.append(r.getString(R.string.unexpected_fatal_error)).append("\n");
 							throwable = t;
 						} finally {
 							if (!TextUtils.isEmpty(log)) {

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -28,6 +28,7 @@
 	<string name="sent_message_to_application">Enviado \'%1$s\' a la aplicación por %2$s.</string>
 	<string name="sent_message_to_phone">Enviado \'%1$s\' a %2$s.</string>
 	<string name="fatal_error">Error fatal: %s.</string>
+	<string name="unexpected_fatal_error">Error fatal no esperado.</string>
 	<string name="refresh_rate">Intervalo de actualización</string>
 	<string name="refresh">Actualizar</string>
 	<string name="refreshing">Actualizando&#8230;</string>
@@ -78,6 +79,7 @@
 	<string name="no_connection">No parece haber conexión a internet. Asegurate de tener conexión y reabre esta aplicación.</string>
 	<string name="add_plus_to_outgoing">Añadir + a sms enviados?</string>
 	<string name="flag">Bandera</string>
-	<string name="invalid_channel_name_password_combination">la combinación de nombre de canal y Invalid channel name y clave es incorrecta</string>
+	<string name="invalid_channel_name_password_combination">la combinación de nombre de canal y clave es incorrecta</string>
 	<string name="received_http_status_code">se obtuvo el código de estado HTTP: %s</string>
+	<string name="qst_client_error">Error conectando al servidor de mensajes</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
 	<string name="sent_message_to_application">Sent \'%1$s\' to application from %2$s.</string>
 	<string name="sent_message_to_phone">Sent \'%1$s\' to %2$s.</string>
 	<string name="fatal_error">Fatal error: %s.</string>
+	<string name="unexpected_fatal_error">Unexpected fatal error.</string>
 	<string name="internet_connection_error">Error accessing server: %s.</string>
 	<string name="internet_connection_error_title">Connection Error</string>
 	<string name="refresh_rate">Refresh rate</string>
@@ -80,4 +81,5 @@
 	<string name="flag">Flag</string>
 	<string name="invalid_channel_name_password_combination">invalid channel name/password combination</string>
 	<string name="received_http_status_code">received HTTP status code: %s</string>
+	<string name="qst_client_error">Error connecting to messaging server.</string>
 </resources>


### PR DESCRIPTION
Unexpected QstClientErrors are displayed as "Error connecting to messaging server", and unexpected throwables are displayed as "Unexpected fatal error". The internals of the error can be seen by long-clicking on the entry. Non-errors have no long-click event.

Fixes #1.
