### PR TITLE
Message retries

### DIFF
--- a/app/src/main/java/org/instedd/geochat/lgw/LGWPreferenceActivity.java
+++ b/app/src/main/java/org/instedd/geochat/lgw/LGWPreferenceActivity.java
@@ -81,6 +81,8 @@ public class LGWPreferenceActivity extends PreferenceActivity implements
 
 	private void updatePreferenceSummaries() {
 		updateRefreshRateSummary();
+		updatetMaxMessageAgeSummary();
+		updateWaitBetweenMessagesSummary();
 		updateEndpointUrlSummary();
 		updateNameSummary();
 		// The password is not shown in summary
@@ -95,6 +97,8 @@ public class LGWPreferenceActivity extends PreferenceActivity implements
 		setPasswordPopUpValue();
 		setCountryCodePopUpValue();
 		setTelephoneNumberPopUpValue();
+		setMaxMessageAgeValue();
+		setWaitBetweenMessagesValue();
 		addPlusToOutgoingPreference().setDefaultValue(true);
 		addPlusToOutgoingPreference().setChecked(settings.storedAddPlusToOutgoing());
 	}
@@ -120,8 +124,26 @@ public class LGWPreferenceActivity extends PreferenceActivity implements
 				refreshRatePreference());
 	}
 
+	private void updatetMaxMessageAgeSummary() {
+		updateListPreferenceSummary(String.valueOf(settings.storedMaxMessageAgeInDays()),
+				maxMessageAgePreference());
+	}
+
+	private void updateWaitBetweenMessagesSummary() {
+		updateListPreferenceSummary(String.valueOf(settings.storedWaitBetweenMessagesInSeconds()),
+				waitBetweenMessagesPreference());
+	}
+
 	private void setTelephoneNumberPopUpValue() {
 		telephoneNumberPreference().setText(storedTelephoneNumber());
+	}
+
+	private void setMaxMessageAgeValue() {
+		maxMessageAgePreference().setValue(String.valueOf(settings.storedMaxMessageAgeInDays()));
+	}
+
+	private void setWaitBetweenMessagesValue() {
+		waitBetweenMessagesPreference().setValue(String.valueOf(settings.storedWaitBetweenMessagesInSeconds()));
 	}
 
 	private void setEndpointUrlPopUpValue() {
@@ -166,6 +188,14 @@ public class LGWPreferenceActivity extends PreferenceActivity implements
 
 	private ListPreference refreshRatePreference() {
 		return (ListPreference) findPreference(Settings.REFRESH_RATE);
+	}
+
+	private ListPreference maxMessageAgePreference() {
+		return (ListPreference) findPreference(Settings.MAX_MESSAGE_AGE_IN_DAYS);
+	}
+
+	private ListPreference waitBetweenMessagesPreference() {
+		return (ListPreference) findPreference(Settings.WAIT_BETWEEN_MESSAGES_IN_SECONDS);
 	}
 
 	private ListPreference countryPreference() {

--- a/app/src/main/java/org/instedd/geochat/lgw/OutgoingMessagesActivity.java
+++ b/app/src/main/java/org/instedd/geochat/lgw/OutgoingMessagesActivity.java
@@ -66,14 +66,15 @@ public class OutgoingMessagesActivity extends ListActivity implements OnItemLong
 		builder.setTitle(getResources().getString(R.string.MT));
 		builder.setItems(items, new OnClickListener() {
 			public void onClick(DialogInterface dialog, int which) {
-				int id = cursor.getInt(cursor.getColumnIndex(Messages._ID));
 				switch(which) {
 				case 0: // retry
+					int id = cursor.getInt(cursor.getColumnIndex(Messages._ID));
 					new GeoChatLgwData(OutgoingMessagesActivity.this).resetOutgoingMessageTries(id);
 					Actions.refresh(OutgoingMessagesActivity.this, handler, R.string.retrying);
 					break;
-				case 1: // delete 
-					new GeoChatLgwData(OutgoingMessagesActivity.this).deleteOutgoingMessage(id);
+				case 1: // delete
+					String guid = cursor.getString(cursor.getColumnIndex(Messages.GUID));
+					new GeoChatLgwData(OutgoingMessagesActivity.this).deleteOutgoingMessageAndMarkAsFailed(guid);
 					break;
 				}
 			}

--- a/app/src/main/java/org/instedd/geochat/lgw/Settings.java
+++ b/app/src/main/java/org/instedd/geochat/lgw/Settings.java
@@ -76,7 +76,7 @@ public class Settings implements ISettings {
 
 	public int storedMaxMessageAgeInDays() { return Integer.parseInt(openRead().getString(MAX_MESSAGE_AGE_IN_DAYS, "7")); }
 
-	public int storedWaitBetweenMessagesInSeconds() { return Integer.parseInt(openRead().getString(WAIT_BETWEEN_MESSAGES_IN_SECONDS, "10")); }
+	public int storedWaitBetweenMessagesInSeconds() { return Integer.parseInt(openRead().getString(WAIT_BETWEEN_MESSAGES_IN_SECONDS, "0")); }
 
 	public void saveLastReceivedMessageId(String id) {
 		Editor editor = openWrite();

--- a/app/src/main/java/org/instedd/geochat/lgw/Settings.java
+++ b/app/src/main/java/org/instedd/geochat/lgw/Settings.java
@@ -24,6 +24,8 @@ public class Settings implements ISettings {
 	public final static String NUMBER = "telephoneNumber";
 	public final static String LAST_RECEIVED_MESSAGE_ID = "lastSentMessageId";
 	public final static String ADD_PLUS_TO_OUTGOING = "addPlusToOutgoing";
+	public final static String MAX_MESSAGE_AGE_IN_DAYS = "maxMessageAge";
+	public final static String WAIT_BETWEEN_MESSAGES_IN_SECONDS = "waitBetweenMessages";
 
 	private final Context context;
 	private NuntiumClient nuntiumClient;
@@ -71,6 +73,10 @@ public class Settings implements ISettings {
 	public String storedCountryCode() {
 		return openRead().getString(COUNTRY_CODE, null);
 	}
+
+	public int storedMaxMessageAgeInDays() { return Integer.parseInt(openRead().getString(MAX_MESSAGE_AGE_IN_DAYS, "7")); }
+
+	public int storedWaitBetweenMessagesInSeconds() { return Integer.parseInt(openRead().getString(WAIT_BETWEEN_MESSAGES_IN_SECONDS, "10")); }
 
 	public void saveLastReceivedMessageId(String id) {
 		Editor editor = openWrite();

--- a/app/src/main/java/org/instedd/geochat/lgw/Uris.java
+++ b/app/src/main/java/org/instedd/geochat/lgw/Uris.java
@@ -10,6 +10,7 @@ import android.net.Uri;
 public class Uris {
 	
 	public final static Uri OutgoingMessagesToBeSent = Uri.withAppendedPath(OutgoingMessages.CONTENT_URI, "not_sending");
+	public final static Uri OutgoingMessagesExpired = Uri.withAppendedPath(OutgoingMessages.CONTENT_URI, "expired");
 	public final static Uri OldLogs = Uri.withAppendedPath(Logs.CONTENT_URI, "old");
 
 	public static Uri outgoingMessage(int id) {

--- a/app/src/main/java/org/instedd/geochat/lgw/Uris.java
+++ b/app/src/main/java/org/instedd/geochat/lgw/Uris.java
@@ -9,7 +9,7 @@ import android.net.Uri;
 
 public class Uris {
 	
-	public final static Uri OutgoingMessagesNotBeingSent = Uri.withAppendedPath(OutgoingMessages.CONTENT_URI, "not_sending");
+	public final static Uri OutgoingMessagesToBeSent = Uri.withAppendedPath(OutgoingMessages.CONTENT_URI, "not_sending");
 	public final static Uri OldLogs = Uri.withAppendedPath(Logs.CONTENT_URI, "old");
 
 	public static Uri outgoingMessage(int id) {

--- a/app/src/main/java/org/instedd/geochat/lgw/data/GeoChatLgw.java
+++ b/app/src/main/java/org/instedd/geochat/lgw/data/GeoChatLgw.java
@@ -118,6 +118,8 @@ public class GeoChatLgw {
          */
         public static final String REMAINING_PARTS = "_remaining";
 
+        public static final String NEXT_TRY = "_next_try";
+
         public final static String[] PROJECTION = {
     		_ID,
     		GUID,
@@ -127,7 +129,8 @@ public class GeoChatLgw {
     		WHEN,
     		SENDING,
 			TRIES,
-			REMAINING_PARTS
+			REMAINING_PARTS,
+            NEXT_TRY
 		};
 	}
 

--- a/app/src/main/java/org/instedd/geochat/lgw/data/GeoChatLgw.java
+++ b/app/src/main/java/org/instedd/geochat/lgw/data/GeoChatLgw.java
@@ -118,7 +118,7 @@ public class GeoChatLgw {
          */
         public static final String REMAINING_PARTS = "_remaining";
 
-        public static final String NEXT_TRY = "_next_try";
+        public static final String RETRY_AT = "_next_try";
 
         public final static String[] PROJECTION = {
     		_ID,
@@ -130,7 +130,7 @@ public class GeoChatLgw {
     		SENDING,
 			TRIES,
 			REMAINING_PARTS,
-            NEXT_TRY
+			RETRY_AT
 		};
 	}
 

--- a/app/src/main/java/org/instedd/geochat/lgw/data/GeoChatLgwData.java
+++ b/app/src/main/java/org/instedd/geochat/lgw/data/GeoChatLgwData.java
@@ -76,6 +76,10 @@ public class GeoChatLgwData {
 	public int deleteIncomingMessage(int id) {
 		return content.delete(Uris.incomingMessage(id), null, null);
 	}
+
+	public int deleteExpiredOutgoingMessages() {
+		return content.delete(Uris.OutgoingMessagesExpired, null, null);
+	}
 	
 	public int resetOutgoingMessageTries(int id) {
 		return content.update(Uris.outgoingMessage(id), TRIES_ZERO, null, null);

--- a/app/src/main/java/org/instedd/geochat/lgw/data/GeoChatLgwData.java
+++ b/app/src/main/java/org/instedd/geochat/lgw/data/GeoChatLgwData.java
@@ -35,6 +35,7 @@ public class GeoChatLgwData {
 	private final static ContentValues TRIES_ZERO = new ContentValues();
 	static {
 		TRIES_ZERO.put(OutgoingMessages.TRIES, 0);
+		TRIES_ZERO.put(OutgoingMessages.RETRY_AT, 0);
 	}
 	
 	private final ContentResolver content;
@@ -90,11 +91,12 @@ public class GeoChatLgwData {
 		}
 	}
 	
-	public int markOutgoingMessageAsNotBeingSent(String guid, int tries) {
+	public int markOutgoingMessageAsNotBeingSent(String guid, int tries, long retryAt) {
 		synchronized(notSendingLock) {
 			ContentValues values = new ContentValues();
 			values.put(OutgoingMessages.SENDING, 0);
 			values.put(OutgoingMessages.TRIES, tries);
+			values.put(OutgoingMessages.RETRY_AT, retryAt);
 			return content.update(Uris.outgoingMessage(guid), values, OutgoingMessages.SENDING + " = 1", null);
 		}
 	}
@@ -141,14 +143,19 @@ public class GeoChatLgwData {
 	}
 	
 	public Message[] getOutgoingMessagesNotBeingSentAndMarkAsBeingSent() {
+
+		final String retryAtFilter = "(" + OutgoingMessages.RETRY_AT + " IS NULL OR " + OutgoingMessages.RETRY_AT + " <= ?)";
+		final long currentTime = System.currentTimeMillis();
+		final String[] retryAtArgs = new String[] { String.valueOf(currentTime) };
+
 		synchronized(notSendingLock) {
-			Cursor c = content.query(Uris.OutgoingMessagesNotBeingSent, OutgoingMessages.PROJECTION, null, null, null);
+			Cursor c = content.query(Uris.OutgoingMessagesToBeSent, OutgoingMessages.PROJECTION, retryAtFilter, retryAtArgs, null);
 			try {
 				int count = c.getCount();
 				if (count == 0)
 					return null;
 				
-				content.update(Uris.OutgoingMessagesNotBeingSent, BEING_SENT, null, null);
+				content.update(Uris.OutgoingMessagesToBeSent, BEING_SENT, retryAtFilter, retryAtArgs);
 				
 				Message[] outgoing = new Message[count];
 				for (int i = 0; c.moveToNext(); i++) {

--- a/app/src/main/java/org/instedd/geochat/lgw/data/GeoChatLgwData.java
+++ b/app/src/main/java/org/instedd/geochat/lgw/data/GeoChatLgwData.java
@@ -61,8 +61,9 @@ public class GeoChatLgwData {
 		return content.delete(Uris.outgoingMessage(guid), null, null);
 	}
 	
-	public int deleteOutgoingMessage(int id) {
-		return content.delete(Uris.outgoingMessage(id), null, null);
+	public void deleteOutgoingMessageAndMarkAsFailed(String guid) {
+		markOutgoingMessageAsFailed(guid);
+		deleteOutgoingMessage(guid);
 	}
 	
 	public int deleteAllOutgoingMessages() {
@@ -82,8 +83,7 @@ public class GeoChatLgwData {
 		int count = c.getCount();
 		for (int i = 0; c.moveToNext(); i++) {
 			String guid = c.getString(0);
-			markOutgoingMessageAsFailed(guid);
-			deleteOutgoingMessage(guid);
+			deleteOutgoingMessageAndMarkAsFailed(guid);
 		}
 
 		return count;

--- a/app/src/main/java/org/instedd/geochat/lgw/data/GeoChatLgwData.java
+++ b/app/src/main/java/org/instedd/geochat/lgw/data/GeoChatLgwData.java
@@ -77,8 +77,16 @@ public class GeoChatLgwData {
 		return content.delete(Uris.incomingMessage(id), null, null);
 	}
 
-	public int deleteExpiredOutgoingMessages() {
-		return content.delete(Uris.OutgoingMessagesExpired, null, null);
+	public int deleteExpiredOutgoingMessagesAndMarkAsFailed() {
+		Cursor c = content.query(Uris.OutgoingMessagesExpired, new String[] { GeoChatLgw.Messages.GUID }, null, null, null);
+		int count = c.getCount();
+		for (int i = 0; c.moveToNext(); i++) {
+			String guid = c.getString(0);
+			markOutgoingMessageAsFailed(guid);
+			deleteOutgoingMessage(guid);
+		}
+
+		return count;
 	}
 	
 	public int resetOutgoingMessageTries(int id) {
@@ -223,6 +231,13 @@ public class GeoChatLgwData {
 		ContentValues values = new ContentValues();
 		values.put(Statuses.GUID, guid);
 		values.put(Statuses.SENT, 1);
+		content.insert(Statuses.CONTENT_URI, values);
+	}
+
+	public void markOutgoingMessageAsFailed(String guid) {
+		ContentValues values = new ContentValues();
+		values.put(Statuses.GUID, guid);
+		values.put(Statuses.SENT, 0);
 		content.insert(Statuses.CONTENT_URI, values);
 	}
 

--- a/app/src/main/java/org/instedd/geochat/lgw/data/GeoChatLgwProvider.java
+++ b/app/src/main/java/org/instedd/geochat/lgw/data/GeoChatLgwProvider.java
@@ -316,6 +316,13 @@ public class GeoChatLgwProvider extends ContentProvider {
                 orderBy = Statuses.DEFAULT_SORT_ORDER;
             }
             break;
+		case OUTGOING_EXPIRED:
+			qb.setTables(OUTGOING_TABLE_NAME);
+			qb.appendWhere(Messages.WHEN + " < " + (System.currentTimeMillis() - Message.MAX_AGE_IN_MINUTES * 60 * 1000));
+			if (TextUtils.isEmpty(sortOrder)) {
+				orderBy = Messages.DEFAULT_SORT_ORDER;
+			}
+			break;
         default:
             throw new IllegalArgumentException("Unknown URI " + uri);
         }

--- a/app/src/main/java/org/instedd/geochat/lgw/data/GeoChatLgwProvider.java
+++ b/app/src/main/java/org/instedd/geochat/lgw/data/GeoChatLgwProvider.java
@@ -28,7 +28,7 @@ public class GeoChatLgwProvider extends ContentProvider {
 	public static final String TAG = "GeoChatLgwProvider";
 	
 	private static final String DATABASE_NAME = "geochat_lgw.db";
-    private static final int DATABASE_VERSION = 5;
+    private static final int DATABASE_VERSION = 6;
     
     private static final String INCOMING_TABLE_NAME = "incoming";
     private static final String OUTGOING_TABLE_NAME = "outgoing";
@@ -81,7 +81,8 @@ public class GeoChatLgwProvider extends ContentProvider {
                     + Messages.WHEN + " INTEGER,"
                     + OutgoingMessages.SENDING + " INTEGER,"
                     + OutgoingMessages.TRIES + " INTEGER,"
-                    + OutgoingMessages.REMAINING_PARTS + " INTEGER"
+                    + OutgoingMessages.REMAINING_PARTS + " INTEGER,"
+                    + OutgoingMessages.NEXT_TRY + " INTEGER"
                     + ");");
             db.execSQL("CREATE TABLE " + LOGS_TABLE_NAME + " ("
                     + BaseColumns._ID + " INTEGER PRIMARY KEY,"
@@ -105,6 +106,14 @@ public class GeoChatLgwProvider extends ContentProvider {
             if (oldVersion < 5) {
                 createStatuses(db);
             }
+            if (oldVersion < 6) {
+                addNextTryToOutgoing(db);
+            }
+        }
+
+        private void addNextTryToOutgoing(SQLiteDatabase db) {
+            db.execSQL("ALTER TABLE " + OUTGOING_TABLE_NAME + " ADD COLUMN "
+                + OutgoingMessages.NEXT_TRY + " INTEGER");
         }
     }
 
@@ -380,6 +389,7 @@ public class GeoChatLgwProvider extends ContentProvider {
         
         sOutgoingProjectionMap.put(OutgoingMessages.SENDING, OutgoingMessages.SENDING);
         sOutgoingProjectionMap.put(OutgoingMessages.TRIES, OutgoingMessages.TRIES);
+        sOutgoingProjectionMap.put(OutgoingMessages.NEXT_TRY, OutgoingMessages.NEXT_TRY);
         
         sLogsProjectionMap = new HashMap<String, String>();
         sLogsProjectionMap.put(Logs._ID, Logs._ID);

--- a/app/src/main/java/org/instedd/geochat/lgw/data/GeoChatLgwProvider.java
+++ b/app/src/main/java/org/instedd/geochat/lgw/data/GeoChatLgwProvider.java
@@ -3,6 +3,7 @@ package org.instedd.geochat.lgw.data;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.instedd.geochat.lgw.Settings;
 import org.instedd.geochat.lgw.data.GeoChatLgw.IncomingMessages;
 import org.instedd.geochat.lgw.data.GeoChatLgw.Logs;
 import org.instedd.geochat.lgw.data.GeoChatLgw.Messages;
@@ -120,7 +121,15 @@ public class GeoChatLgwProvider extends ContentProvider {
     }
 
     private DatabaseHelper mOpenHelper;
-    
+
+	private Settings settings;
+
+	private Settings getSettings() {
+		if (this.settings == null) {
+			this.settings = new Settings(getContext());
+		} return this.settings;
+	}
+
     @Override
 	public int delete(Uri uri, String where, String[] whereArgs) {
 		SQLiteDatabase db = mOpenHelper.getWritableDatabase();
@@ -171,7 +180,7 @@ public class GeoChatLgwProvider extends ContentProvider {
             break;
         }
 		case OUTGOING_EXPIRED: {
-			count = db.delete(OUTGOING_TABLE_NAME, Messages.WHEN + " < " + (System.currentTimeMillis() - Message.MAX_AGE_IN_MINUTES * 60 * 1000)
+			count = db.delete(OUTGOING_TABLE_NAME, Messages.WHEN + " < " + (System.currentTimeMillis() - getSettings().storedMaxMessageAgeInDays() * 24 * 60 * 60 * 1000)
 					+ (!TextUtils.isEmpty(where) ? " AND (" + where + ')' : ""), whereArgs);
 			break;
 		}
@@ -318,7 +327,7 @@ public class GeoChatLgwProvider extends ContentProvider {
             break;
 		case OUTGOING_EXPIRED:
 			qb.setTables(OUTGOING_TABLE_NAME);
-			qb.appendWhere(Messages.WHEN + " < " + (System.currentTimeMillis() - Message.MAX_AGE_IN_MINUTES * 60 * 1000));
+			qb.appendWhere(Messages.WHEN + " < " + (System.currentTimeMillis() - getSettings().storedMaxMessageAgeInDays() * 24 * 60 * 60 * 1000));
 			if (TextUtils.isEmpty(sortOrder)) {
 				orderBy = Messages.DEFAULT_SORT_ORDER;
 			}

--- a/app/src/main/java/org/instedd/geochat/lgw/data/GeoChatLgwProvider.java
+++ b/app/src/main/java/org/instedd/geochat/lgw/data/GeoChatLgwProvider.java
@@ -82,7 +82,7 @@ public class GeoChatLgwProvider extends ContentProvider {
                     + OutgoingMessages.SENDING + " INTEGER,"
                     + OutgoingMessages.TRIES + " INTEGER,"
                     + OutgoingMessages.REMAINING_PARTS + " INTEGER,"
-                    + OutgoingMessages.NEXT_TRY + " INTEGER"
+                    + OutgoingMessages.RETRY_AT + " INTEGER"
                     + ");");
             db.execSQL("CREATE TABLE " + LOGS_TABLE_NAME + " ("
                     + BaseColumns._ID + " INTEGER PRIMARY KEY,"
@@ -113,7 +113,7 @@ public class GeoChatLgwProvider extends ContentProvider {
 
         private void addNextTryToOutgoing(SQLiteDatabase db) {
             db.execSQL("ALTER TABLE " + OUTGOING_TABLE_NAME + " ADD COLUMN "
-                + OutgoingMessages.NEXT_TRY + " INTEGER");
+                + OutgoingMessages.RETRY_AT + " INTEGER");
         }
     }
 
@@ -292,7 +292,7 @@ public class GeoChatLgwProvider extends ContentProvider {
         	break;
         case OUTGOING_NOT_SENDING:
         	qb.setTables(OUTGOING_TABLE_NAME);
-        	qb.appendWhere(OutgoingMessages.SENDING + " = 0 AND (" + OutgoingMessages.TRIES + " IS NULL OR " + OutgoingMessages.TRIES + " < 3)");
+        	qb.appendWhere(OutgoingMessages.SENDING + " = 0");
         	if (TextUtils.isEmpty(sortOrder)) {
                 orderBy = Messages.DEFAULT_SORT_ORDER;
             }
@@ -389,7 +389,7 @@ public class GeoChatLgwProvider extends ContentProvider {
         
         sOutgoingProjectionMap.put(OutgoingMessages.SENDING, OutgoingMessages.SENDING);
         sOutgoingProjectionMap.put(OutgoingMessages.TRIES, OutgoingMessages.TRIES);
-        sOutgoingProjectionMap.put(OutgoingMessages.NEXT_TRY, OutgoingMessages.NEXT_TRY);
+        sOutgoingProjectionMap.put(OutgoingMessages.RETRY_AT, OutgoingMessages.RETRY_AT);
         
         sLogsProjectionMap = new HashMap<String, String>();
         sLogsProjectionMap.put(Logs._ID, Logs._ID);

--- a/app/src/main/java/org/instedd/geochat/lgw/data/GeoChatLgwProvider.java
+++ b/app/src/main/java/org/instedd/geochat/lgw/data/GeoChatLgwProvider.java
@@ -8,6 +8,7 @@ import org.instedd.geochat.lgw.data.GeoChatLgw.Logs;
 import org.instedd.geochat.lgw.data.GeoChatLgw.Messages;
 import org.instedd.geochat.lgw.data.GeoChatLgw.OutgoingMessages;
 import org.instedd.geochat.lgw.data.GeoChatLgw.Statuses;
+import org.instedd.geochat.lgw.msg.Message;
 
 import android.content.ContentProvider;
 import android.content.ContentUris;
@@ -50,6 +51,7 @@ public class GeoChatLgwProvider extends ContentProvider {
     public final static int INCOMING_ID = 9;
     public final static int STATUS = 10;
     public final static int STATUS_GUID = 11;
+	public final static int OUTGOING_EXPIRED = 12;
     
     public static final UriMatcher URI_MATCHER;
     
@@ -168,6 +170,11 @@ public class GeoChatLgwProvider extends ContentProvider {
                     + (!TextUtils.isEmpty(where) ? " AND (" + where + ')' : ""), whereArgs);
             break;
         }
+		case OUTGOING_EXPIRED: {
+			count = db.delete(OUTGOING_TABLE_NAME, Messages.WHEN + " < " + (System.currentTimeMillis() - Message.MAX_AGE_IN_MINUTES * 60 * 1000)
+					+ (!TextUtils.isEmpty(where) ? " AND (" + where + ')' : ""), whereArgs);
+			break;
+		}
         default:
             throw new IllegalArgumentException("Unknown URI " + uri);
         }
@@ -365,6 +372,7 @@ public class GeoChatLgwProvider extends ContentProvider {
         URI_MATCHER.addURI(GeoChatLgw.AUTHORITY, "outgoing/#", OUTGOING_ID);
         URI_MATCHER.addURI(GeoChatLgw.AUTHORITY, "outgoing/guid/*", OUTGOING_GUID);
         URI_MATCHER.addURI(GeoChatLgw.AUTHORITY, "outgoing/not_sending", OUTGOING_NOT_SENDING);
+		URI_MATCHER.addURI(GeoChatLgw.AUTHORITY, "outgoing/expired", OUTGOING_EXPIRED);
         URI_MATCHER.addURI(GeoChatLgw.AUTHORITY, "logs", LOGS);
         URI_MATCHER.addURI(GeoChatLgw.AUTHORITY, "logs/old", LOGS_OLD);
         URI_MATCHER.addURI(GeoChatLgw.AUTHORITY, "status", STATUS);

--- a/app/src/main/java/org/instedd/geochat/lgw/msg/Message.java
+++ b/app/src/main/java/org/instedd/geochat/lgw/msg/Message.java
@@ -15,6 +15,10 @@ public class Message {
 	public long when;
 	public int tries;
 	public int remainingParts;
+	public long retryAt;
+
+	public static int[] RETRIES_INTERVALS_IN_MINUTES = new int[] { 1, 1, 2, 5, 15, 30, 60, 180};
+	public static int MAX_AGE_IN_MINUTES = 7 * 24 * 60; // 7 days
 	
 	public static Message readFrom(Cursor c) {
 		// Check the projections in GeoChatLgw
@@ -28,6 +32,7 @@ public class Message {
 		if (c.getColumnCount() > 7) {
 			msg.tries = c.getInt(7);
 			msg.remainingParts = c.getInt(8);
+			msg.retryAt = c.getLong(9);
 		}
 		return msg;
 	}
@@ -46,6 +51,12 @@ public class Message {
 	
 	public ContentValues toContentValues() {
 		return toContentValues(guid, from, to, text, when);
+	}
+
+	public void incrementTries() {
+		this.tries++;
+		int intervalInMinutes = (this.tries >= RETRIES_INTERVALS_IN_MINUTES.length ? RETRIES_INTERVALS_IN_MINUTES[RETRIES_INTERVALS_IN_MINUTES.length-1] : RETRIES_INTERVALS_IN_MINUTES[this.tries]);
+		this.retryAt = System.currentTimeMillis() + intervalInMinutes * 60 * 1000;
 	}
 
 }

--- a/app/src/main/java/org/instedd/geochat/lgw/msg/Message.java
+++ b/app/src/main/java/org/instedd/geochat/lgw/msg/Message.java
@@ -17,9 +17,8 @@ public class Message {
 	public int remainingParts;
 	public long retryAt;
 
-	public static int[] RETRIES_INTERVALS_IN_MINUTES = new int[] { 1, 1, 2, 5, 15, 30, 60, 180};
-	public static int MAX_AGE_IN_MINUTES = 7 * 24 * 60; // 7 days
-	
+	public static int[] RETRIES_INTERVALS_IN_MINUTES = new int[] { 1, 1, 2, 5, 15, 30, 60, 180, 360 };
+
 	public static Message readFrom(Cursor c) {
 		// Check the projections in GeoChatLgw
 		Message msg = new Message();

--- a/app/src/main/java/org/instedd/geochat/lgw/trans/Transceiver.java
+++ b/app/src/main/java/org/instedd/geochat/lgw/trans/Transceiver.java
@@ -79,8 +79,8 @@ public class Transceiver {
 				break;
 			default:
 				if (msg != null) {
-					msg.tries++;
-					if (data.markOutgoingMessageAsNotBeingSent(guid, msg.tries) > 0) {
+					msg.incrementTries();
+					if (data.markOutgoingMessageAsNotBeingSent(guid, msg.tries, msg.retryAt) > 0) {
 						data.log(context.getResources().getString(R.string.message_could_not_be_sent_tries, msg.text, msg.to, msg.tries));
 					}
 				}
@@ -283,8 +283,8 @@ public class Transceiver {
 							if (resync)
 								continue;
 
-							// 2. Send pending messages (those that were sent at
-							// least once and failed)
+							// 2. Send pending messages to be sent (those that were sent at
+							// least once and failed, with retryAt less than current time)
 							Message[] pending = data
 									.getOutgoingMessagesNotBeingSentAndMarkAsBeingSent();
 							sendMessages(pending);
@@ -331,6 +331,11 @@ public class Transceiver {
 						} finally {
 							if (!TextUtils.isEmpty(log)) {
 								data.log(log.toString().trim(), throwable);
+								if (throwable != null) {
+									Log.e("transceiver", "Error in transceiver: " + log.toString().trim(), throwable);
+								} else {
+									Log.d("transceiver", log.toString().trim());
+								}
 							}
 						}
 					} else {

--- a/app/src/main/java/org/instedd/geochat/lgw/trans/Transceiver.java
+++ b/app/src/main/java/org/instedd/geochat/lgw/trans/Transceiver.java
@@ -283,8 +283,8 @@ public class Transceiver {
 							if (resync)
 								continue;
 
-							// 2.a. Delete messages over max age
-							int deletedCount = data.deleteExpiredOutgoingMessages();
+							// 2.a. Delete messages over max age and mark them as failed
+							int deletedCount = data.deleteExpiredOutgoingMessagesAndMarkAsFailed();
 							if (deletedCount > 0) {
 								data.log(r.getString(R.string.deleted_expired_messages, deletedCount, Integer.valueOf(Message.MAX_AGE_IN_MINUTES / 60 / 24)));
 							}

--- a/app/src/main/java/org/instedd/geochat/lgw/trans/Transceiver.java
+++ b/app/src/main/java/org/instedd/geochat/lgw/trans/Transceiver.java
@@ -283,7 +283,16 @@ public class Transceiver {
 							if (resync)
 								continue;
 
-							// 2. Send pending messages to be sent (those that were sent at
+							// 2.a. Delete messages over max age
+							int deletedCount = data.deleteExpiredOutgoingMessages();
+							if (deletedCount > 0) {
+								data.log(r.getString(R.string.deleted_expired_messages, deletedCount, Integer.valueOf(Message.MAX_AGE_IN_MINUTES / 60 / 24)));
+							}
+
+							if (resync)
+								continue;
+
+							// 2.b. Send pending messages to be sent (those that were sent at
 							// least once and failed, with retryAt less than current time)
 							Message[] pending = data
 									.getOutgoingMessagesNotBeingSentAndMarkAsBeingSent();

--- a/app/src/main/java/org/instedd/geochat/lgw/trans/Transceiver.java
+++ b/app/src/main/java/org/instedd/geochat/lgw/trans/Transceiver.java
@@ -203,7 +203,7 @@ public class Transceiver {
 
 		synchronized (sendLock) {
 			try {
-				sendLock.wait(10000);
+				sendLock.wait(settings.storedWaitBetweenMessagesInSeconds() * 1000);
 			} catch (InterruptedException e) {
 			}
 		}
@@ -286,7 +286,7 @@ public class Transceiver {
 							// 2.a. Delete messages over max age and mark them as failed
 							int deletedCount = data.deleteExpiredOutgoingMessagesAndMarkAsFailed();
 							if (deletedCount > 0) {
-								data.log(r.getString(R.string.deleted_expired_messages, deletedCount, Integer.valueOf(Message.MAX_AGE_IN_MINUTES / 60 / 24)));
+								data.log(r.getString(R.string.deleted_expired_messages, deletedCount, Integer.valueOf(settings.storedMaxMessageAgeInDays())));
 							}
 
 							if (resync)

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -18,13 +18,6 @@
 		android:id="@+id/country"
 		android:dialogTitle="@string/country"
 		/>
-	<ListPreference
-		android:title="@string/refresh_rate"
-		android:key="refreshRate"
-		android:id="@+id/refreshRate"
-		android:entries="@array/refresh_rate_entries"
-		android:entryValues="@array/refresh_rate_entry_values"
-		/>
 	<CheckBoxPreference
 		android:title="@string/add_plus_to_outgoing"
 		android:key="addPlusToOutgoing"
@@ -32,9 +25,8 @@
 		/>
 
 	<PreferenceCategory
-		android:title="@string/advanced"
+		android:title="@string/msg_server_settings"
 		>
-		
 		<EditTextPreference
 			android:title="@string/endpoint_url"
 			android:key="endpointUrl"
@@ -54,6 +46,32 @@
 			android:dialogTitle="@string/password"
 			android:password="true"
 			/>
-			
-		</PreferenceCategory>
+
+	</PreferenceCategory>
+
+	<PreferenceCategory
+		android:title="@string/advanced"
+		>
+		<ListPreference
+			android:title="@string/refresh_rate"
+			android:key="refreshRate"
+			android:id="@+id/refreshRate"
+			android:entries="@array/refresh_rate_entries"
+			android:entryValues="@array/refresh_rate_entry_values"
+			/>
+		<ListPreference
+			android:title="@string/max_message_age"
+			android:key="maxMessageAge"
+			android:id="@+id/maxMessageAge"
+			android:entries="@array/max_message_age_entries"
+			android:entryValues="@array/max_message_age_entry_values"
+			/>
+		<ListPreference
+			android:title="@string/wait_between_messages"
+			android:key="waitBetweenMessages"
+			android:id="@+id/waitBetweenMessages"
+			android:entries="@array/wait_between_messages_entries"
+			android:entryValues="@array/wait_between_messages_entry_values"
+			/>
+	</PreferenceCategory>
 </PreferenceScreen>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -64,6 +64,42 @@
 		<item>30</item>
 		<item>60</item>
 	</string-array>
+	<string-array name="max_message_age_entries">
+		<item>1 día</item>
+		<item>3 días</item>
+		<item>5 días</item>
+		<item>7 días</item>
+		<item>15 días</item>
+		<item>30 días</item>
+		<item>60 días</item>
+	</string-array>
+	<string-array name="max_message_age_entry_values">
+		<item>1</item>
+		<item>3</item>
+		<item>5</item>
+		<item>7</item>
+		<item>15</item>
+		<item>30</item>
+		<item>60</item>
+	</string-array>
+	<string-array name="wait_between_messages_entries">
+		<item>10 segundos</item>
+		<item>15 segundos</item>
+		<item>20 segundos</item>
+		<item>30 segundos</item>
+		<item>45 segundos</item>
+		<item>1 minuto</item>
+		<item>2 minutos</item>
+	</string-array>
+	<string-array name="wait_between_messages_entry_values">
+		<item>10</item>
+		<item>15</item>
+		<item>20</item>
+		<item>30</item>
+		<item>45</item>
+		<item>60</item>
+		<item>120</item>
+	</string-array>
 	<string name="advanced">Avanzadas</string>
 	<string name="internet_connection_error">Error accediendo al servidor: %s.</string>
 	<string name="internet_connection_error_title">Error de Conexión</string>
@@ -84,4 +120,7 @@
 	<string name="qst_client_error">Error conectando al servidor de mensajes</string>
 	<string name="confirm_reset_configuration">Está seguro de reiniciar la configuración? Será necesario volver a configurar el gateway para poder enviar y recibir mensajes.</string>
 	<string name="deleted_expired_messages">Se descartaron %1$s mensaje(s) no enviados por más de %2$s días</string>
+	<string name="max_message_age">Borrar mensajes fallidos después de</string>
+	<string name="wait_between_messages">Esperar entre mensajes</string>
+	<string name="msg_server_settings">Servidor de mensajes</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -83,6 +83,8 @@
 		<item>60</item>
 	</string-array>
 	<string-array name="wait_between_messages_entries">
+		<item>Sin espera</item>
+		<item>5 segundos</item>
 		<item>10 segundos</item>
 		<item>15 segundos</item>
 		<item>20 segundos</item>
@@ -92,6 +94,8 @@
 		<item>2 minutos</item>
 	</string-array>
 	<string-array name="wait_between_messages_entry_values">
+		<item>0</item>
+		<item>5</item>
 		<item>10</item>
 		<item>15</item>
 		<item>20</item>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -81,9 +81,7 @@
 	<string name="flag">Bandera</string>
 	<string name="invalid_channel_name_password_combination">la combinación de nombre de canal y clave es incorrecta</string>
 	<string name="received_http_status_code">se obtuvo el código de estado HTTP: %s</string>
-<<<<<<< HEAD
 	<string name="qst_client_error">Error conectando al servidor de mensajes</string>
-=======
 	<string name="confirm_reset_configuration">Está seguro de reiniciar la configuración? Será necesario volver a configurar el gateway para poder enviar y recibir mensajes.</string>
->>>>>>> Confirm before clearing configuration
+	<string name="deleted_expired_messages">Se descartaron %1$s mensaje(s) no enviados por más de %2$s días</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,8 @@
 		<item>60</item>
 	</string-array>
 	<string-array name="wait_between_messages_entries">
+		<item>No wait</item>
+		<item>5 seconds</item>
 		<item>10 seconds</item>
 		<item>15 seconds</item>
 		<item>20 seconds</item>
@@ -94,6 +96,8 @@
 		<item>2 minutes</item>
 	</string-array>
 	<string-array name="wait_between_messages_entry_values">
+		<item>0</item>
+		<item>5</item>
 		<item>10</item>
 		<item>15</item>
 		<item>20</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,42 @@
 		<item>30</item>
 		<item>60</item>
 	</string-array>
+	<string-array name="max_message_age_entries">
+		<item>1 day</item>
+		<item>3 days</item>
+		<item>5 days</item>
+		<item>7 days</item>
+		<item>15 days</item>
+		<item>30 days</item>
+		<item>60 days</item>
+	</string-array>
+	<string-array name="max_message_age_entry_values">
+		<item>1</item>
+		<item>3</item>
+		<item>5</item>
+		<item>7</item>
+		<item>15</item>
+		<item>30</item>
+		<item>60</item>
+	</string-array>
+	<string-array name="wait_between_messages_entries">
+		<item>10 seconds</item>
+		<item>15 seconds</item>
+		<item>20 seconds</item>
+		<item>30 seconds</item>
+		<item>45 seconds</item>
+		<item>1 minute</item>
+		<item>2 minutes</item>
+	</string-array>
+	<string-array name="wait_between_messages_entry_values">
+		<item>10</item>
+		<item>15</item>
+		<item>20</item>
+		<item>30</item>
+		<item>45</item>
+		<item>60</item>
+		<item>120</item>
+	</string-array>
 	<string name="advanced">Advanced</string>
 	<string name="next">Next</string>
 	<string name="country">Country</string>
@@ -84,4 +120,7 @@
 	<string name="qst_client_error">Error connecting to messaging server.</string>
 	<string name="confirm_reset_configuration">Are you sure you want to clear the current configuration? You will have to pair the gateway again with an application to continue sending and receiving messages.</string>
 	<string name="deleted_expired_messages">Discarded %1$s expired outgoing message(s) older than %2$s days</string>
+	<string name="max_message_age">Delete failed messages after</string>
+	<string name="wait_between_messages">Wait between sending messages</string>
+	<string name="msg_server_settings">Messages server</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,9 +81,7 @@
 	<string name="flag">Flag</string>
 	<string name="invalid_channel_name_password_combination">invalid channel name/password combination</string>
 	<string name="received_http_status_code">received HTTP status code: %s</string>
-<<<<<<< HEAD
 	<string name="qst_client_error">Error connecting to messaging server.</string>
-=======
 	<string name="confirm_reset_configuration">Are you sure you want to clear the current configuration? You will have to pair the gateway again with an application to continue sending and receiving messages.</string>
->>>>>>> Confirm before clearing configuration
+	<string name="deleted_expired_messages">Discarded %1$s expired outgoing message(s) older than %2$s days</string>
 </resources>


### PR DESCRIPTION
- Add a `retry_at` field to outgoing messages, and only resend failed messages after an increasing retry interval.
- Manually retrying a message clears all retries and starts over.
- New _max age_ option, that purges messages older than specified age, an marks them as failed in Nuntium.
- New _wait between messages_ option to manually set throttling; set to no wait by default.

Fixes #2 
Fixes #3
