### PR TITLE
require https

### DIFF
--- a/app/src/main/java/org/instedd/geochat/lgw/msg/NuntiumClient.java
+++ b/app/src/main/java/org/instedd/geochat/lgw/msg/NuntiumClient.java
@@ -131,7 +131,7 @@ public class NuntiumClient {
 	public NuntiumTicket requestTicketFor(String telephoneNumber)
 			throws NuntiumClientException {
 		try {
-			HttpResponse response = restClient.post("http://" + nuntiumUrl
+			HttpResponse response = restClient.post("https://" + nuntiumUrl
 					+ "/tickets.json?", "address=" + telephoneNumber, null);
 
 			check(response);


### PR DESCRIPTION
The [Philippines Nuntium server](https://nuntium.surveda-ph.org/)  is set up to require https, which is a good thing. The problem is the mobile gateway uses HTTP for creating a ticket. So when using the mobile gateway with a server that requires https you end up with a 404. For the Philippines, its probably easy enough to allow for HTTP, but the better fix here is to use https on all mobile gateway traffic.